### PR TITLE
Remove PII data

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -24,6 +24,9 @@ if (typeof window !== "undefined") {
 
   const LDProvider = await asyncWithLDProvider({
     clientSideID: process.env.NEXT_PUBLIC_LD_CLIENT_KEY || "",
+    options: {
+      privateAttributes: ['email']
+    },
     reactOptions: {
       useCamelCaseFlagKeys: false,
     },

--- a/utils/contexts/login.js
+++ b/utils/contexts/login.js
@@ -18,10 +18,28 @@ export const LoginProvider = ({ children }) => {
 
   const loginUser = async (user, email) => {
     const context = await client?.getContext();
+
+    const hashCode = (str) => {
+      var hash = 0,
+        i = 0,
+        len = str.length;
+      while (i < len) {
+        hash = ((hash << 5) - hash + str.charCodeAt(i++)) << 0;
+      }
+      const key = pad(hash + 2147483647 + 1, 12);
+      return "key_" + key;
+    }
+    
+    const pad = (num, size) => {
+      num = num.toString();
+      while (num.length < size) num = "0" + num;
+      return num;
+    }
+
     console.log("loginUser",context)
     context.user.name = user;
     context.user.email = email;
-    context.user.key = email;
+    context.user.key = hashCode(email);
     context.audience.key = uuidv4().slice(0, 10);
     context.user.launchclub = launchClubStatus;
     setIsLoggedIn(true);


### PR DESCRIPTION
👋 Team, I discussed this with Tony and he proposed I open a PR to suggest a change to remove PII data from the demo environment.

Especially in EMEA region customer are very sensitive around PII data. Therefore the demo will improve if we can show that we are not sharing any PII data. This can be done by:

- Making email a private attribute
- Hashing the email address and replace email address with the hashed value.

Every time the same email address logs in (Jenn, Cody, ...) the hash will be the same, so it does not create a new context.

I'd be also fine with any other solution that uses a non-PII key for contexts.
