### PR TITLE
Add context attributes to improve targeting

### DIFF
--- a/utils/contexts/login.js
+++ b/utils/contexts/login.js
@@ -24,6 +24,25 @@ export const LoginProvider = ({ children }) => {
     context.user.key = email;
     context.audience.key = uuidv4().slice(0, 10);
     context.user.launchclub = launchClubStatus;
+
+    switch (user) {
+      case 'Cody':
+        context.user.segment = "Family";
+        context.user.country = "Sweden";
+        break;
+      case 'Jenn':
+        context.user.segment = "Young Adult";
+        context.user.country = "United Kingdom";
+        break;
+      case 'Alysha':
+        context.user.segment = "Affluent Adult";
+        context.user.country = "United States";
+        break;
+      default:
+        context.user.segment = "Student";
+        context.user.country = "United States";
+    }
+
     setIsLoggedIn(true);
     setUser(user);
     setEmail(email);


### PR DESCRIPTION
👋 Team, I discussed this with Tony and he proposed I open a PR so the team can evaluate.

Currently the targeting options in the demo are quite limited, so I have been using a hack to add two attributes to the `user` context for Cody, Jenn and Alyshia:

- `segment`: a customer segment
- `country`: a country value

This allows for targeting by customer segment and country where the customer is based in the Toggle Bank application.

I did a quick and dirty hack here to add the values, but it does the job.

We do have a location context, but that defaults to the same values for your users as it is based on the actual location you are visiting from.