### PR TITLE
Updated Gov and ToggleBank Demos

### DIFF
--- a/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
+++ b/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
@@ -56,7 +56,7 @@ class DemoBuilder:
         
         # Run LDGeneratorsRunner.py in parallel as a subprocess
         proc = subprocess.Popen([
-            "python", os.path.join(os.path.dirname(__file__), "LDGeneratorsRunner.py")
+            "python3", os.path.join(os.path.dirname(__file__), "LDGeneratorsRunner.py")
         ], env=env)
         
         self.setup_release_pipeline()

--- a/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
+++ b/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
@@ -19,7 +19,7 @@ class DemoBuilder:
     client_id = ""
     sdk_key = ""
     phase_ids = {}
-       
+
     # InitializeDemoBuilder
     def __init__(self, api_key, email, api_key_user, project_key, project_name):
         self.api_key = api_key

--- a/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
+++ b/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
@@ -19,7 +19,7 @@ class DemoBuilder:
     client_id = ""
     sdk_key = ""
     phase_ids = {}
-    
+       
     # InitializeDemoBuilder
     def __init__(self, api_key, email, api_key_user, project_key, project_name):
         self.api_key = api_key
@@ -884,8 +884,8 @@ class DemoBuilder:
         res = self.ldproject.add_segment_to_flag("release-new-investment-stock-api", "beta-users", "production")
         res = self.ldproject.add_segment_to_flag("showCardsSectionComponent", "development-team", "production")
         res = self.ldproject.add_segment_to_flag("patchShowCardsSectionComponent", "development-team", "production")
-        res = self.ldproject.add_segment_to_flag("riskmgmtbureauDBGuardedRelease", "beta-users", "production")
-        res = self.ldproject.add_segment_to_flag("riskmgmtbureauAPIGuardedRelease", "beta-users", "production")
+        res = self.ldproject.add_segment_to_flag("riskmgmtbureauDBGuardedRelease", "development-team", "production")
+        res = self.ldproject.add_segment_to_flag("riskmgmtbureauAPIGuardedRelease", "development-team", "production")
         
     def toggle_flags(self):
         res = self.ldproject.toggle_flag(

--- a/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
+++ b/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
@@ -5,16 +5,6 @@ from dotenv import load_dotenv
 import subprocess
 # Load environment variables from .env file
 load_dotenv()
-# testing
-# hello
-# hello
-# hello
-# hello
-# hello
-# hello
-# hello
-# hello
-# hello
 
 class DemoBuilder:
     project_created = False

--- a/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
+++ b/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
@@ -551,7 +551,7 @@ class DemoBuilder:
             "(Bayesian) Funnel Experiment: ToggleBank Multi-Step Signup Flow",
             "production",
             "releaseNewSignupPromo",
-            "Testing whether the new multi-step signup flow improves conversion rates compared to the old single-page signup in ToggleBank.",
+            "Testing which marketing banner offer (credit card, mortgage, or cashback) drives the most signup conversions in ToggleBank.",
             metrics=metrics,
             primary_key="signup-flow-completed",
             attributes=["device", "location", "tier", "operating_system"],
@@ -2484,20 +2484,24 @@ class DemoBuilder:
         res = self.ldproject.create_flag(
             "releaseNewSignupPromo",
             "A6 - Funnel Experiment: New Signup Flow - ToggleBank",
-            "This feature flag controls whether users see the new multi-step signup flow or the old decorative Join Now button",
+            "This feature flag controls which promotional offer is displayed in the marketing banner to test which offer drives the most signup conversions",
             [
                 {
-                    "value": True,
-                    "name": "New Multi-Step Signup Flow"
+                    "value": "creditCardOffer",
+                    "name": "Credit Card: 0% APR for 12 months"
                 },
                 {
-                    "value": False,
-                    "name": "Old Decorative Button"
+                    "value": "mortgageOffer", 
+                    "name": "Mortgage: 0.50% off 30 year loan"
+                },
+                {
+                    "value": "cashbackOffer",
+                    "name": "Checking: $200 cashback when you spend $2500+"
                 }
             ],
             tags=["Experimentation", "bank"],
             on_variation=0,
-            off_variation=1,
+            off_variation=2,
         )
 
     def flag_togglebank_swap_widget_positions(self):

--- a/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
+++ b/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
@@ -5,6 +5,16 @@ from dotenv import load_dotenv
 import subprocess
 # Load environment variables from .env file
 load_dotenv()
+# testing
+# hello
+# hello
+# hello
+# hello
+# hello
+# hello
+# hello
+# hello
+# hello
 
 class DemoBuilder:
     project_created = False

--- a/components/ui/bankcomponents/bankHomePage.tsx
+++ b/components/ui/bankcomponents/bankHomePage.tsx
@@ -59,7 +59,9 @@ export default function BankHomePage() {
         // track which marketing offer was clicked
         ldClient?.track("marketing-banner-clicked", {
             offerType: selectedMarketingOffer,
-            offerTitle: marketingBannerOffers[selectedMarketingOffer].title
+            offerTitle: marketingBannerOffers[selectedMarketingOffer].title,
+            experimentKey: "togglebank-signup-funnel-experiment",
+            source: "sticky-banner"
         });
         logLDMetricSent({ 
             metricKey: "marketing-banner-clicked",

--- a/components/ui/bankcomponents/bankHomePage.tsx
+++ b/components/ui/bankcomponents/bankHomePage.tsx
@@ -55,6 +55,21 @@ export default function BankHomePage() {
         router.push("/signup");
     };
 
+    const handleMarketingBannerClick = () => {
+        // track which marketing offer was clicked
+        ldClient?.track("marketing-banner-clicked", {
+            offerType: selectedMarketingOffer,
+            offerTitle: marketingBannerOffers[selectedMarketingOffer].title
+        });
+        logLDMetricSent({ 
+            metricKey: "marketing-banner-clicked",
+            metricValue: selectedMarketingOffer
+        });
+        
+        // proceed to the signup flow
+        handleJoinNowClick();
+    };
+
     // special offers experiment
     const flagValue = flags["showDifferentSpecialOfferString"];
     const validOfferKeys = ["offerA", "offerB", "offerC"] as const;
@@ -203,6 +218,28 @@ export default function BankHomePage() {
                     </div>
                 </div>
             </header>
+
+            {/* marketing banner (A6 experiment) */}
+            <div className="w-full bg-gradient-to-r from-blue-600 to-blue-800 py-6 px-4">
+                <div className="max-w-7xl mx-auto">
+                    <div className="bg-white rounded-lg shadow-lg p-6 mx-4">
+                        <div className="text-center">
+                            <h3 className="text-2xl font-bold text-gray-900 mb-2">
+                                {marketingBannerOffers[selectedMarketingOffer].title}
+                            </h3>
+                            <p className="text-gray-600 mb-4">
+                                {marketingBannerOffers[selectedMarketingOffer].description}
+                            </p>
+                            <button 
+                                onClick={handleMarketingBannerClick}
+                                className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg shadow-md transition-colors duration-200"
+                            >
+                                {marketingBannerOffers[selectedMarketingOffer].cta}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
 
             <div className="z-20 2xl:mt-20" >
                 <div className="flex justify-center mb-6 text-bankhomepagebuttonblue font-sohne tracking-widest">

--- a/components/ui/bankcomponents/bankHomePage.tsx
+++ b/components/ui/bankcomponents/bankHomePage.tsx
@@ -187,6 +187,30 @@ export default function BankHomePage() {
                 </>
             </NavWrapper>
 
+            {/* sticky top marketing banner */}
+            <div className="sticky top-0 z-50 w-full bg-bank-gradient-blue-background shadow-lg">
+                <div className="max-w-7xl mx-auto px-4 py-3">
+                    <div className="flex items-center justify-between text-white">
+                        <div className="flex items-center space-x-4">
+                            <div className="flex items-center space-x-2">
+                                <div className="w-2 h-2 bg-yellow-400 rounded-full animate-pulse"></div>
+                                <span className="text-sm font-sohnelight tracking-widest">LIMITED TIME</span>
+                            </div>
+                            <div className="hidden sm:block w-px h-6 bg-white/30"></div>
+                            <div className="text-sm sm:text-base font-sohne">
+                                {marketingBannerOffers[selectedMarketingOffer].title}
+                            </div>
+                        </div>
+                        <button 
+                            onClick={handleMarketingBannerClick}
+                            className="bg-bank-gradient-text-color hover:bg-white hover:text-bank-gradient-text-color text-white px-4 py-2 rounded-full text-sm font-sohnelight transition-all duration-200 shadow-md hover:shadow-lg"
+                        >
+                            {marketingBannerOffers[selectedMarketingOffer].cta}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
             <header className={`w-full relative `}>
                 <Image src={heroBackgroundCreditcard} className='absolute right-0 w-2/6 xl:w-2/6 min-w-lg max-w-lg' alt="Icon Background" />
                 <Image src={heroBackgroundDollarSign} className='absolute left-0 bottom-0 w-2/6 xl:w-2/6 max-w-lg' alt="Icon Background" />
@@ -218,28 +242,6 @@ export default function BankHomePage() {
                     </div>
                 </div>
             </header>
-
-            {/* marketing banner (A6 experiment) */}
-            <div className="w-full bg-gradient-to-r from-blue-600 to-blue-800 py-6 px-4">
-                <div className="max-w-7xl mx-auto">
-                    <div className="bg-white rounded-lg shadow-lg p-6 mx-4">
-                        <div className="text-center">
-                            <h3 className="text-2xl font-bold text-gray-900 mb-2">
-                                {marketingBannerOffers[selectedMarketingOffer].title}
-                            </h3>
-                            <p className="text-gray-600 mb-4">
-                                {marketingBannerOffers[selectedMarketingOffer].description}
-                            </p>
-                            <button 
-                                onClick={handleMarketingBannerClick}
-                                className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-8 rounded-lg shadow-md transition-colors duration-200"
-                            >
-                                {marketingBannerOffers[selectedMarketingOffer].cta}
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
 
             <div className="z-20 2xl:mt-20" >
                 <div className="flex justify-center mb-6 text-bankhomepagebuttonblue font-sohne tracking-widest">
@@ -363,15 +365,8 @@ export default function BankHomePage() {
                     </div>
                 </div>
             </div>
-
-
-
         </motion.main>
-
-
-
     );
-
 }
 
 const bankHomePageValues: any = {

--- a/components/ui/bankcomponents/bankHomePage.tsx
+++ b/components/ui/bankcomponents/bankHomePage.tsx
@@ -49,21 +49,22 @@ export default function BankHomePage() {
     const flags = useFlags();
 
     const handleJoinNowClick = () => {
-        const releaseNewSignupPromoFlag = flags[RELEASE_NEW_SIGNUP_PROMO_LDFLAG_KEY];
-        
-        if (releaseNewSignupPromoFlag) {
-            // new: multi-step signup flow
-            ldClient?.track(SIGN_UP_STARTED);
-            logLDMetricSent({ metricKey: SIGN_UP_STARTED });
-            router.push("/signup");
-        }
-        // old: do nothing (decorative button)
+        // signup flow
+        ldClient?.track(SIGN_UP_STARTED);
+        logLDMetricSent({ metricKey: SIGN_UP_STARTED });
+        router.push("/signup");
     };
 
     // special offers experiment
     const flagValue = flags["showDifferentSpecialOfferString"];
     const validOfferKeys = ["offerA", "offerB", "offerC"] as const;
     const selectedOffer: "offerA" | "offerB" | "offerC" = flagValue && validOfferKeys.includes(flagValue) ? flagValue : "offerA";
+
+    // marketing banner experiment for A6
+    const marketingBannerFlag = flags[RELEASE_NEW_SIGNUP_PROMO_LDFLAG_KEY];
+    const validMarketingOfferKeys = ["creditCardOffer", "mortgageOffer", "cashbackOffer"] as const;
+    const selectedMarketingOffer: "creditCardOffer" | "mortgageOffer" | "cashbackOffer" = 
+        marketingBannerFlag && validMarketingOfferKeys.includes(marketingBannerFlag) ? marketingBannerFlag : "creditCardOffer";
 
     // variations
     const specialOffers = {
@@ -81,6 +82,25 @@ export default function BankHomePage() {
             title: "Platinum rewards",
             description: "Earn unlimited cashback on every purchase with our premium credit card. No annual fee.",
             image: specialOfferCC
+        }
+    } as const;
+
+    // marketing banner variations for A6
+    const marketingBannerOffers = {
+        creditCardOffer: {
+            title: "New credit card holders get 0% APR for 12 months",
+            description: "Apply now and enjoy 0% introductory APR for 12 months on purchases and balance transfers.",
+            cta: "Apply Now"
+        },
+        mortgageOffer: {
+            title: "Get 0.50% off 30 year mortgage loan",
+            description: "Lock in our best rate with 0.50% off our standard 30-year mortgage rate.",
+            cta: "Get Pre-approved"
+        },
+        cashbackOffer: {
+            title: "Get $200 cashback when you spend $2500 or more using checking accounts",
+            description: "Open a new checking account and earn $200 cashback when you spend $2500+ in the first 3 months.",
+            cta: "Open Account"
         }
     } as const;
 

--- a/components/ui/govcomponents/RiskAlertsPanel.tsx
+++ b/components/ui/govcomponents/RiskAlertsPanel.tsx
@@ -154,10 +154,10 @@ const RiskAlertsPanel = () => {
   const userRole = context?.user?.role;
   const isLoggedIn = context?.user && !context?.user?.anonymous;
   
-  // only showing for beta users
-  const isBetaUser = isLoggedIn && userRole === "Beta";
+  /// only showing for developers/development team
+  const isDeveloper = isLoggedIn && userRole === "Developer";
   
-  if (!isBetaUser) {
+  if (!isDeveloper) {
     return null;
   }
 
@@ -287,4 +287,4 @@ const RiskAlertsPanel = () => {
   );
 };
 
-export default RiskAlertsPanel; 
+export default RiskAlertsPanel;

--- a/components/ui/govcomponents/RiskAssessmentDashboard.tsx
+++ b/components/ui/govcomponents/RiskAssessmentDashboard.tsx
@@ -63,10 +63,10 @@ const RiskAssessmentDashboard = () => {
   const userRole = context?.user?.role;
   const isLoggedIn = context?.user && !context?.user?.anonymous;
   
-  // only showing for beta users
-  const isBetaUser = isLoggedIn && userRole === "Beta";
+  // only show for developers/development
+  const isDeveloper = isLoggedIn && userRole === "Developer";
   
-  if (!isBetaUser) {
+  if (!isDeveloper) {
     return null;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@radix-ui/react-toast": "^1.1.5",
         "@radix-ui/react-tooltip": "^1.1.6",
         "@tanstack/react-table": "^8.10.7",
+        "autoprefixer": "^10.4.19",
         "chart.js": "^4.4.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
@@ -90,7 +91,6 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@types/uuid": "^9.0.7",
-        "autoprefixer": "^10.4.19",
         "drizzle-kit": "^0.31.1",
         "postcss": "^8",
         "postcss-cli": "^9.1.0",
@@ -6935,7 +6935,6 @@
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
       "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9022,7 +9021,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -11894,7 +11892,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.1.6",
     "@tanstack/react-table": "^8.10.7",
+    "autoprefixer": "^10.4.19",
     "chart.js": "^4.4.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
@@ -80,8 +81,7 @@
     "uuid": "^9.0.1",
     "uuid4": "^2.0.3",
     "uuidv4": "^6.2.13",
-    "zod": "^3.22.4",
-    "autoprefixer": "^10.4.19"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/crypto-js": "^4.2.2",

--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -20,7 +20,7 @@ export default function SuccessPage() {
     const ldClient = useLDClient();
     const { logLDMetricSent } = useContext(LiveLogsContext);
 
-    // Track final conversion when page loads
+    // track final conversion when page loads
     useEffect(() => {
         ldClient?.track(SIGN_UP_FLOW_COMPLETED);
         logLDMetricSent({ metricKey: SIGN_UP_FLOW_COMPLETED });

--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useContext, useEffect } from "react";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { CheckCircle } from "lucide-react";
 import { useSignup } from "@/components/SignUpProvider";
 import { INITIAL_USER_SIGNUP_DATA } from "@/utils/constants";
@@ -19,12 +20,13 @@ export default function SuccessPage() {
     const { isLoggedIn, loginUser } = useContext(LoginContext);
     const ldClient = useLDClient();
     const { logLDMetricSent } = useContext(LiveLogsContext);
+    const router = useRouter();
 
     // track final conversion when page loads
     useEffect(() => {
         ldClient?.track(SIGN_UP_FLOW_COMPLETED);
         logLDMetricSent({ metricKey: SIGN_UP_FLOW_COMPLETED });
-    }, [ldClient, logLDMetricSent]);
+    }, [ldClient]);
 
 	return (
 		<WrapperMain className="flex flex-col items-center justify-center py-4">
@@ -81,9 +83,8 @@ export default function SuccessPage() {
 					href="/bank"
 					className="mt-4 w-full rounded-full bg-blue-500 py-3 text-center font-medium text-white transition-colors hover:bg-blue-600"
 					onClick={async () => {
-						!isLoggedIn && loginUser(STARTER_PERSONAS[0].personaemail);
+						!isLoggedIn && loginUser("user@launchmail.io");
 						await wait(0.5);
-						updateUserData(INITIAL_USER_SIGNUP_DATA);
 					}}
 				>
 					Go to Dashboard

--- a/pages/success.tsx
+++ b/pages/success.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import Link from "next/link";
 import { CheckCircle } from "lucide-react";
 import { useSignup } from "@/components/SignUpProvider";
@@ -10,10 +10,21 @@ import { COMPANY_LOGOS, BANK } from "@/utils/constants";
 import Image from "next/image";
 import WrapperMain from "@/components/ui/WrapperMain";
 import LoginContext from "@/utils/contexts/login";
+import { useLDClient } from "launchdarkly-react-client-sdk";
+import LiveLogsContext from "@/utils/contexts/LiveLogsContext";
+import { SIGN_UP_FLOW_COMPLETED } from "@/components/generators/experimentation-automation/experimentationConstants";
 
 export default function SuccessPage() {
 	const { userData, updateUserData } = useSignup();
     const { isLoggedIn, loginUser } = useContext(LoginContext);
+    const ldClient = useLDClient();
+    const { logLDMetricSent } = useContext(LiveLogsContext);
+
+    // Track final conversion when page loads
+    useEffect(() => {
+        ldClient?.track(SIGN_UP_FLOW_COMPLETED);
+        logLDMetricSent({ metricKey: SIGN_UP_FLOW_COMPLETED });
+    }, [ldClient, logLDMetricSent]);
 
 	return (
 		<WrapperMain className="flex flex-col items-center justify-center py-4">


### PR DESCRIPTION
This PR adds the A6 funnel experiment for ToggleBank by introducing a marketing banner that shows different promotional offers (0% APR credit card, mortgage discount, cashback offer). The goal is to test which promotion drives the most sign-up conversions. As part of this change, the sign-up flow now always runs (previous conditional logic removed).

I also included a small fix to the gov demo: dashboards are now viewed in Developer instead of Beta User.