### PR TITLE
Add AI tools provisioning to multi-agent demo setup

### DIFF
--- a/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
+++ b/.github/workflows/demo_provisioning_scripts/DemoBuilder.py
@@ -1,3 +1,4 @@
+import json
 import LDPlatform
 import time
 import os
@@ -242,6 +243,9 @@ class DemoBuilder:
     def create_ai_config(self):
         print("Creating AI Config...")
         
+        # Create foundational AI tools first so variations can reference them via tools [{key, version}]
+        tool_versions = self.create_foundational_ai_tools()
+        
         ############# FUTURE UPDATE  ######################
          
         # print("AI Models: Destination Recommendations")
@@ -255,7 +259,7 @@ class DemoBuilder:
         ##################################################
         self.create_togglebot_ai_config()
         self.create_togglebot_self_heal_ai_config()
-        self.create_togglebot_multi_agent_ai_configs()
+        self.create_togglebot_multi_agent_ai_configs(tool_versions)
         self.create_llm_as_judge_ai_config()
         self.create_government_publicbot_ai_config()
         self.create_custom_financial_models()
@@ -1559,6 +1563,62 @@ class DemoBuilder:
             ]
         )
 
+    def create_foundational_ai_tools(self):
+        """Create the four foundational AI tools and return a dict mapping key -> version."""
+        print("Creating foundational AI tools...")
+        tool_defs = [
+            {
+                "key": "get-customer-context",
+                "description": "Returns a lightweight customer profile (name, tier, location, segment) so agents can tailor routing, tone, and recommendations.",
+                "schema": {"properties": {}, "additionalProperties": False, "required": []},
+            },
+            {
+                "key": "search-knowledge-base",
+                "description": "Searches the curated product and policy knowledge base. Use when answering factual or policy-style questions.",
+                "schema": {
+                    "properties": {"query": {"type": "string", "description": "Search query or question"}},
+                    "additionalProperties": False,
+                    "required": ["query"],
+                },
+            },
+            {
+                "key": "rewrite-response-for-channel",
+                "description": "Adapts content into the right tone and format for the target channel (e.g. in-app, email, sms).",
+                "schema": {
+                    "properties": {
+                        "content": {"type": "string", "description": "Content to rewrite"},
+                        "channel": {"type": "string", "description": "Target channel (e.g. in-app, email)"},
+                    },
+                    "additionalProperties": False,
+                    "required": ["content", "channel"],
+                },
+            },
+            {
+                "key": "calculate-loan-payment",
+                "description": "Calculates monthly loan payment, total payment, and total interest. For Loans & Credit specialist.",
+                "schema": {
+                    "properties": {
+                        "principal": {"type": "number", "description": "Loan principal amount"},
+                        "annualRatePercent": {"type": "number", "description": "Annual interest rate (e.g. 7 for 7%)"},
+                        "termMonths": {"type": "integer", "description": "Loan term in months"},
+                    },
+                    "additionalProperties": False,
+                    "required": ["principal", "annualRatePercent", "termMonths"],
+                },
+            },
+        ]
+        tool_versions = {}
+        for t in tool_defs:
+            resp = self.ldproject.create_ai_tool(t["key"], description=t.get("description"), schema=t["schema"])
+            try:
+                data = json.loads(resp.text)
+                tool_versions[t["key"]] = data.get("version", 1)
+            except (json.JSONDecodeError, AttributeError):
+                tool_versions[t["key"]] = 1
+            time.sleep(0.3)
+        print("Done creating foundational AI tools.")
+        return tool_versions
+
     def create_togglebot_ai_config(self):
         res = self.ldproject.create_ai_config(
             "ai-config--togglebot",
@@ -1738,7 +1798,14 @@ class DemoBuilder:
         
         self.ldproject.update_flag_client_side_availability("ai-config--togglebot-self-heal-chatbot")
 
-    def create_togglebot_multi_agent_ai_configs(self):
+    def create_togglebot_multi_agent_ai_configs(self, tool_versions=None):
+        if tool_versions is None:
+            tool_versions = {}
+
+        def _tools(*keys):
+            """Build a tools array of {key, version} dicts for the variation POST."""
+            return [{"key": k, "version": tool_versions.get(k, 1)} for k in keys]
+
         model_config = {
             "modelName": "gpt-5-mini",
             "parameters": {
@@ -1751,15 +1818,9 @@ class DemoBuilder:
         # -----------------------------------------------------------
         # 1. Triage Agent
         # -----------------------------------------------------------
-        self.ldproject.create_ai_config(
-            "ai-config--togglebot-triage",
-            "ToggleBot Triage Agent - ToggleBank",
-            "Routes customer queries to the appropriate banking specialist based on topic classification",
-            tags,
-            mode="agent"
-        )
         triage_instructions = (
             "You are a banking query classifier for ToggleBank. Classify the customer's query into exactly one category.\n\n"
+            "Use the following customer context when classifying: {{ customer_context }}\n\n"
             "Categories:\n"
             "- accounts: Checking/savings accounts, balances, transactions, account management, statements, fees\n"
             "- loans_credit: Personal loans, home mortgages, auto loans, credit cards, credit applications, interest rates, payments\n"
@@ -1770,6 +1831,13 @@ class DemoBuilder:
             "Return ONLY a JSON object (no markdown fencing):\n"
             "{\"category\": \"<key>\", \"confidence\": <0-1>, \"reasoning\": \"<one sentence>\"}"
         )
+        self.ldproject.create_ai_config(
+            "ai-config--togglebot-triage",
+            "ToggleBot Triage Agent - ToggleBank",
+            "Routes customer queries to the appropriate banking specialist based on topic classification",
+            tags,
+            mode="agent"
+        )
         self.ldproject.create_ai_config_versions(
             "ai-config--togglebot-triage",
             "gpt-5-mini-triage",
@@ -1777,7 +1845,11 @@ class DemoBuilder:
             "GPT-5 Mini - Triage",
             model_config,
             instructions=triage_instructions,
-            description="Classifies banking queries into specialist categories"
+            description="Classifies banking queries into specialist categories",
+        )
+        self.ldproject.patch_variation_tools(
+            "ai-config--togglebot-triage", "gpt-5-mini-triage",
+            _tools("get-customer-context"),
         )
         time.sleep(1)
         self.ldproject.toggle_flag("ai-config--togglebot-triage", "on", "production")
@@ -1788,13 +1860,6 @@ class DemoBuilder:
         # -----------------------------------------------------------
         # 2. Accounts Specialist
         # -----------------------------------------------------------
-        self.ldproject.create_ai_config(
-            "ai-config--togglebot-accounts-specialist",
-            "ToggleBot Accounts Specialist - ToggleBank",
-            "Specialist agent for checking/savings accounts, balances, transactions, and account management queries",
-            tags,
-            mode="agent"
-        )
         accounts_instructions = (
             "You are ToggleBank's Accounts Specialist. You have deep expertise in checking accounts, savings accounts, "
             "money market accounts, CDs, account fees, transaction history, and account management.\n\n"
@@ -1802,11 +1867,19 @@ class DemoBuilder:
             "If the question requires account-specific information you don't have, explain what the customer should do "
             "to get that information (e.g., log in to online banking, visit a branch, call support).\n\n"
             "Keep your response factual, helpful, and under 200 words unless the question requires a longer explanation.\n\n"
+            "Customer context: {{ customer_context }}\n\n"
             "User Context:\n"
             "- User Name: {{ ldctx.user.name }}\n"
             "- Account Tier: {{ ldctx.user.tier }}\n"
             "- City: {{ ldctx.location }}\n\n"
             "User's question: {{ userInput }}"
+        )
+        self.ldproject.create_ai_config(
+            "ai-config--togglebot-accounts-specialist",
+            "ToggleBot Accounts Specialist - ToggleBank",
+            "Specialist agent for checking/savings accounts, balances, transactions, and account management queries",
+            tags,
+            mode="agent"
         )
         self.ldproject.create_ai_config_versions(
             "ai-config--togglebot-accounts-specialist",
@@ -1815,7 +1888,11 @@ class DemoBuilder:
             "GPT-5 Mini - Accounts",
             model_config,
             instructions=accounts_instructions,
-            description="Handles checking/savings account queries"
+            description="Handles checking/savings account queries",
+        )
+        self.ldproject.patch_variation_tools(
+            "ai-config--togglebot-accounts-specialist", "gpt-5-mini-accounts",
+            _tools("get-customer-context", "search-knowledge-base"),
         )
         time.sleep(1)
         self.ldproject.toggle_flag("ai-config--togglebot-accounts-specialist", "on", "production")
@@ -1826,25 +1903,27 @@ class DemoBuilder:
         # -----------------------------------------------------------
         # 3. Loans & Credit Specialist
         # -----------------------------------------------------------
-        self.ldproject.create_ai_config(
-            "ai-config--togglebot-loans-specialist",
-            "ToggleBot Loans & Credit Specialist - ToggleBank",
-            "Specialist agent for personal loans, mortgages, auto loans, credit cards, and credit-related queries",
-            tags,
-            mode="agent"
-        )
         loans_instructions = (
             "You are ToggleBank's Loans & Credit Specialist. You have deep expertise in personal loans, home mortgages, "
             "auto loans, credit cards, lines of credit, interest rates, loan applications, payment schedules, and "
             "credit-related policies.\n\n"
             "Answer the customer's question thoroughly and accurately. Provide specific rate ranges or policy details "
             "when relevant. If the question requires application-specific information, guide the customer on next steps.\n\n"
+            "If a loan payment estimate is provided below, use it in your response: {{ loan_payment_result }}\n\n"
             "Keep your response factual, helpful, and under 200 words unless the question requires a longer explanation.\n\n"
+            "Customer context: {{ customer_context }}\n\n"
             "User Context:\n"
             "- User Name: {{ ldctx.user.name }}\n"
             "- Account Tier: {{ ldctx.user.tier }}\n"
             "- City: {{ ldctx.location }}\n\n"
             "User's question: {{ userInput }}"
+        )
+        self.ldproject.create_ai_config(
+            "ai-config--togglebot-loans-specialist",
+            "ToggleBot Loans & Credit Specialist - ToggleBank",
+            "Specialist agent for personal loans, mortgages, auto loans, credit cards, and credit-related queries",
+            tags,
+            mode="agent"
         )
         self.ldproject.create_ai_config_versions(
             "ai-config--togglebot-loans-specialist",
@@ -1853,7 +1932,11 @@ class DemoBuilder:
             "GPT-5 Mini - Loans",
             model_config,
             instructions=loans_instructions,
-            description="Handles loan and credit queries"
+            description="Handles loan and credit queries",
+        )
+        self.ldproject.patch_variation_tools(
+            "ai-config--togglebot-loans-specialist", "gpt-5-mini-loans",
+            _tools("get-customer-context", "search-knowledge-base", "calculate-loan-payment"),
         )
         time.sleep(1)
         self.ldproject.toggle_flag("ai-config--togglebot-loans-specialist", "on", "production")
@@ -1864,13 +1947,6 @@ class DemoBuilder:
         # -----------------------------------------------------------
         # 4. Investments Specialist
         # -----------------------------------------------------------
-        self.ldproject.create_ai_config(
-            "ai-config--togglebot-investments-specialist",
-            "ToggleBot Investments Specialist - ToggleBank",
-            "Specialist agent for portfolio management, retirement planning, stocks, bonds, and investment advisory",
-            tags,
-            mode="agent"
-        )
         investments_instructions = (
             "You are ToggleBank's Investment Services Specialist. You have deep expertise in portfolio management, "
             "retirement planning (401k, IRA), stocks, bonds, mutual funds, ETFs, investment advisory services, "
@@ -1879,11 +1955,19 @@ class DemoBuilder:
             "that past performance doesn't guarantee future results when appropriate. Guide them to speak with a "
             "financial advisor for personalized advice.\n\n"
             "Keep your response factual, helpful, and under 200 words unless the question requires a longer explanation.\n\n"
+            "Customer context: {{ customer_context }}\n\n"
             "User Context:\n"
             "- User Name: {{ ldctx.user.name }}\n"
             "- Account Tier: {{ ldctx.user.tier }}\n"
             "- City: {{ ldctx.location }}\n\n"
             "User's question: {{ userInput }}"
+        )
+        self.ldproject.create_ai_config(
+            "ai-config--togglebot-investments-specialist",
+            "ToggleBot Investments Specialist - ToggleBank",
+            "Specialist agent for portfolio management, retirement planning, stocks, bonds, and investment advisory",
+            tags,
+            mode="agent"
         )
         self.ldproject.create_ai_config_versions(
             "ai-config--togglebot-investments-specialist",
@@ -1892,7 +1976,11 @@ class DemoBuilder:
             "GPT-5 Mini - Investments",
             model_config,
             instructions=investments_instructions,
-            description="Handles investment and retirement queries"
+            description="Handles investment and retirement queries",
+        )
+        self.ldproject.patch_variation_tools(
+            "ai-config--togglebot-investments-specialist", "gpt-5-mini-investments",
+            _tools("get-customer-context", "search-knowledge-base"),
         )
         time.sleep(1)
         self.ldproject.toggle_flag("ai-config--togglebot-investments-specialist", "on", "production")
@@ -1903,13 +1991,6 @@ class DemoBuilder:
         # -----------------------------------------------------------
         # 5. Transfers Specialist
         # -----------------------------------------------------------
-        self.ldproject.create_ai_config(
-            "ai-config--togglebot-transfers-specialist",
-            "ToggleBot Transfers Specialist - ToggleBank",
-            "Specialist agent for wire transfers, ACH, Zelle, bill pay, mobile deposits, and money movement",
-            tags,
-            mode="agent"
-        )
         transfers_instructions = (
             "You are ToggleBank's Digital Banking & Transfers Specialist. You have deep expertise in wire transfers, "
             "ACH transfers, Zelle payments, bill pay, mobile deposits, online banking features, and money movement "
@@ -1917,11 +1998,19 @@ class DemoBuilder:
             "Answer the customer's question thoroughly and accurately. Include relevant details about transfer limits, "
             "processing times, and fees when applicable.\n\n"
             "Keep your response factual, helpful, and under 200 words unless the question requires a longer explanation.\n\n"
+            "Customer context: {{ customer_context }}\n\n"
             "User Context:\n"
             "- User Name: {{ ldctx.user.name }}\n"
             "- Account Tier: {{ ldctx.user.tier }}\n"
             "- City: {{ ldctx.location }}\n\n"
             "User's question: {{ userInput }}"
+        )
+        self.ldproject.create_ai_config(
+            "ai-config--togglebot-transfers-specialist",
+            "ToggleBot Transfers Specialist - ToggleBank",
+            "Specialist agent for wire transfers, ACH, Zelle, bill pay, mobile deposits, and money movement",
+            tags,
+            mode="agent"
         )
         self.ldproject.create_ai_config_versions(
             "ai-config--togglebot-transfers-specialist",
@@ -1930,7 +2019,11 @@ class DemoBuilder:
             "GPT-5 Mini - Transfers",
             model_config,
             instructions=transfers_instructions,
-            description="Handles transfer and payment queries"
+            description="Handles transfer and payment queries",
+        )
+        self.ldproject.patch_variation_tools(
+            "ai-config--togglebot-transfers-specialist", "gpt-5-mini-transfers",
+            _tools("get-customer-context", "search-knowledge-base"),
         )
         time.sleep(1)
         self.ldproject.toggle_flag("ai-config--togglebot-transfers-specialist", "on", "production")
@@ -1941,24 +2034,25 @@ class DemoBuilder:
         # -----------------------------------------------------------
         # 6. Customer Support Specialist
         # -----------------------------------------------------------
-        self.ldproject.create_ai_config(
-            "ai-config--togglebot-support-specialist",
-            "ToggleBot Customer Support Specialist - ToggleBank",
-            "Specialist agent for general banking questions, technical support, complaints, and miscellaneous inquiries",
-            tags,
-            mode="agent"
-        )
         support_instructions = (
             "You are ToggleBank's Customer Support Specialist. You handle general banking questions, technical support "
             "for online and mobile banking, account inquiries, complaints, and any questions that don't fit a specific domain.\n\n"
             "Answer the customer's question thoroughly and accurately. Be empathetic and solution-oriented. "
             "If the issue requires escalation, explain the process clearly.\n\n"
             "Keep your response factual, helpful, and under 200 words unless the question requires a longer explanation.\n\n"
+            "Customer context: {{ customer_context }}\n\n"
             "User Context:\n"
             "- User Name: {{ ldctx.user.name }}\n"
             "- Account Tier: {{ ldctx.user.tier }}\n"
             "- City: {{ ldctx.location }}\n\n"
             "User's question: {{ userInput }}"
+        )
+        self.ldproject.create_ai_config(
+            "ai-config--togglebot-support-specialist",
+            "ToggleBot Customer Support Specialist - ToggleBank",
+            "Specialist agent for general banking questions, technical support, complaints, and miscellaneous inquiries",
+            tags,
+            mode="agent"
         )
         self.ldproject.create_ai_config_versions(
             "ai-config--togglebot-support-specialist",
@@ -1967,7 +2061,11 @@ class DemoBuilder:
             "GPT-5 Mini - Support",
             model_config,
             instructions=support_instructions,
-            description="Handles general support and miscellaneous queries"
+            description="Handles general support and miscellaneous queries",
+        )
+        self.ldproject.patch_variation_tools(
+            "ai-config--togglebot-support-specialist", "gpt-5-mini-support",
+            _tools("get-customer-context", "search-knowledge-base"),
         )
         time.sleep(1)
         self.ldproject.toggle_flag("ai-config--togglebot-support-specialist", "on", "production")
@@ -1978,16 +2076,10 @@ class DemoBuilder:
         # -----------------------------------------------------------
         # 7. Brand Voice Agent
         # -----------------------------------------------------------
-        self.ldproject.create_ai_config(
-            "ai-config--togglebot-brand-voice",
-            "ToggleBot Brand Voice - ToggleBank",
-            "Takes specialist responses and rewrites them in ToggleBank's warm, professional brand voice",
-            tags,
-            mode="agent"
-        )
         brand_instructions = (
-            "You are ToggleBank's Brand Voice editor. Your job is to take a specialist's response and ensure it "
-            "matches ToggleBank's brand voice.\n\n"
+            "You are ToggleBank's Brand Voice editor. Your job is to take a specialist's response and rewrite it "
+            "for the target channel so it matches ToggleBank's brand voice.\n\n"
+            "Target channel: {{ channel }}. Rewrite the specialist response for this channel.\n\n"
             "Brand guidelines:\n"
             "- Warm, professional, and approachable tone\n"
             "- Address the customer directly using \"you\" / \"your\"\n"
@@ -2002,6 +2094,13 @@ class DemoBuilder:
             "Original customer question: {{ userInput }}\n\n"
             "Specialist's response to rewrite:\n{{ specialist_response }}"
         )
+        self.ldproject.create_ai_config(
+            "ai-config--togglebot-brand-voice",
+            "ToggleBot Brand Voice - ToggleBank",
+            "Takes specialist responses and rewrites them in ToggleBank's warm, professional brand voice",
+            tags,
+            mode="agent"
+        )
         self.ldproject.create_ai_config_versions(
             "ai-config--togglebot-brand-voice",
             "gpt-5-mini-brand",
@@ -2009,7 +2108,11 @@ class DemoBuilder:
             "GPT-5 Mini - Brand Voice",
             model_config,
             instructions=brand_instructions,
-            description="Rewrites specialist responses in ToggleBank brand voice"
+            description="Rewrites specialist responses in ToggleBank brand voice",
+        )
+        self.ldproject.patch_variation_tools(
+            "ai-config--togglebot-brand-voice", "gpt-5-mini-brand",
+            _tools("rewrite-response-for-channel"),
         )
         time.sleep(1)
         self.ldproject.toggle_flag("ai-config--togglebot-brand-voice", "on", "production")

--- a/.github/workflows/demo_provisioning_scripts/LDGeneratorsRunner.py
+++ b/.github/workflows/demo_provisioning_scripts/LDGeneratorsRunner.py
@@ -1,5 +1,16 @@
 import os
-from results_generator import generate_results
+import sys
+
+try:
+    from results_generator import generate_results
+except ImportError as e:
+    if "ldai" in str(e).lower() or "ldai" in repr(e):
+        print(
+            "Skipping generators: ldai module not found. "
+            "Install with: pip install -r requirements.txt (includes launchdarkly-server-sdk-ai)"
+        )
+        sys.exit(0)
+    raise
 
 def main():
     project_key = os.environ.get("LD_PROJECT_KEY")

--- a/.github/workflows/demo_provisioning_scripts/LDPlatform.py
+++ b/.github/workflows/demo_provisioning_scripts/LDPlatform.py
@@ -318,6 +318,61 @@ class LDPlatform:
         if "message" in data:
             print("Error creating AI Config: " + data["message"])
         return response
+
+    ##################################################
+    # Create AI Tool (library tool with key, description, schema)
+    # https://launchdarkly.com/docs/api/ai-configs/post-ai-tool
+    ##################################################
+
+    def create_ai_tool(self, tool_key, description=None, schema=None, custom_parameters=None):
+        """Create an AI tool in the project.
+
+        API reference: https://launchdarkly.com/docs/api/ai-configs/post-ai-tool
+
+        Args:
+            tool_key: Unique key for the tool.
+            description: Human-readable description shown in the LD UI.
+            schema: JSON Schema object describing the tool's parameters.
+            custom_parameters: Optional custom metadata dict.
+
+        Returns:
+            requests.Response — the raw API response (JSON body includes
+            ``key`` and ``version`` on success).
+        """
+        payload = {
+            "key": tool_key,
+            "schema": schema if schema is not None else {"properties": {}, "additionalProperties": False, "required": []}
+        }
+        if description:
+            payload["description"] = description
+        if custom_parameters is not None:
+            payload["customParameters"] = custom_parameters
+        if self.user_id:
+            payload["maintainerId"] = self.user_id
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": self.api_key,
+            "LD-API-Version": "beta",
+        }
+
+        response = self.getrequest(
+            "POST",
+            f"https://app.launchdarkly.com/api/v2/projects/{self.project_key}/ai-tools",
+            json=payload,
+            headers=headers,
+        )
+
+        if response.text.strip():
+            try:
+                data = json.loads(response.text)
+                if "message" in data:
+                    print(f"Error creating AI tool {tool_key}: {data['message']}")
+                else:
+                    print(f"Created AI tool: {tool_key}")
+            except json.JSONDecodeError:
+                pass
+        return response
         
     
     ##################################################
@@ -356,8 +411,7 @@ class LDPlatform:
             headers=headers,
         )
         
-        # Add better error handling for JSON parsing
-        if response.text.strip():  # Only try to parse if response is not empty
+        if response.text.strip():
             try:
                 data = json.loads(response.text)
                 if "message" in data:
@@ -370,7 +424,51 @@ class LDPlatform:
             print("Empty response received from AI config version API")
             
         return response
-    
+
+    ##################################################
+    # Attach tools to an AI Config variation
+    # https://launchdarkly.com/docs/api/ai-configs/patch-ai-config-variation
+    ##################################################
+
+    def patch_variation_tools(self, ai_config_key, variation_key, tools):
+        """Attach tools to an existing AI Config variation.
+
+        Uses PATCH to update the variation with a ``tools`` array of
+        ``{key, version}`` objects.  The variation must already exist
+        (created via ``create_ai_config_versions``).
+
+        Args:
+            ai_config_key: Key of the parent AI Config.
+            variation_key: Key of the variation to update.
+            tools: List of dicts, each with ``key`` (str) and ``version`` (int).
+
+        Returns:
+            requests.Response — the raw API response.
+        """
+        payload = {"tools": tools}
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": self.api_key,
+            "LD-API-Version": "beta",
+        }
+        url = (
+            "https://app.launchdarkly.com/api/v2/projects/"
+            + self.project_key
+            + "/ai-configs/"
+            + ai_config_key
+            + "/variations/"
+            + variation_key
+        )
+        response = self.getrequest("PATCH", url, json=payload, headers=headers)
+        if response.text.strip():
+            try:
+                data = json.loads(response.text)
+                if "message" in data:
+                    print(f"Error attaching tools to {ai_config_key}/{variation_key}: {data['message']}")
+            except json.JSONDecodeError:
+                pass
+        return response
+
     ##################################################
     # Create AI Agent
     ##################################################
@@ -2040,8 +2138,15 @@ class LDPlatform:
             if counter > 8:
                 break
             if status_code != 200:
-                data = json.loads(response.text)
-                print("Error advancing flag phase: " + data["message"])
+                try:
+                    data = json.loads(response.text)
+                    msg = data.get("message", "")
+                except Exception:
+                    msg = response.text or ""
+                if "Phase must have status" in msg or "ReadyToStart" in msg:
+                    print("Warning: Skipping phase advance (phase not in ReadyToStart/Active): " + msg[:80])
+                    break
+                print("Error advancing flag phase: " + msg)
                 time.sleep(3)
 
         return response


### PR DESCRIPTION
## Summary
- Provisions four foundational AI tools (`get-customer-context`, `search-knowledge-base`, `rewrite-response-for-channel`, `calculate-loan-payment`) in LaunchDarkly via the AI Tools API during demo setup
- Attaches the appropriate tools to each multi-agent variation using the PATCH variation endpoint
- Adds {{ customer_context }}, {{ channel }}, and {{ loan_payment_result }} template variables to agent prompts
- Improves resilience: graceful handling of missing ldai module and non-advanceable release pipeline phases

## Test plan

- [ ] Run `DemoBuilder.py` against a fresh project and verify all four AI tools are created (visible under AI > Tools in the LD UI)
- [ ] Verify tools appear attached to the correct agent variations in the UI (e.g. Triage has `get-customer-context`, Loans has all three domain tools)
- [ ] Confirm existing CI workflow (`cloud_demo_environment_create.yaml`) still passes

## Screenshots
<img width="1164" height="267" alt="image" src="https://github.com/user-attachments/assets/14a8b0fc-46d0-44ca-8859-064404d32411" />

<img width="610" height="567" alt="image" src="https://github.com/user-attachments/assets/d490c71b-00b3-4990-94dd-4690518d1ea1" />