### PR TITLE
Send API key on provisioning webhook notifications

### DIFF
--- a/.github/workflows/cloud_demo_environment_deprovisioning.yaml
+++ b/.github/workflows/cloud_demo_environment_deprovisioning.yaml
@@ -41,6 +41,7 @@ jobs:
           curl -X POST "${{ inputs.webhook_url }}" \
             -H "Content-Type: application/json" \
             -H "User-Agent: GitHub-Actions" \
+            -H "x-api-key: ${{ secrets.WEBHOOK_API_KEY }}" \
             -d '{
               "event": "workflow_started",
               "run_id": "${{ github.run_id }}",
@@ -152,6 +153,7 @@ jobs:
           curl -X POST "${{ inputs.webhook_url }}" \
             -H "Content-Type: application/json" \
             -H "User-Agent: GitHub-Actions" \
+            -H "x-api-key: ${{ secrets.WEBHOOK_API_KEY }}" \
             -d '{
               "event": "workflow_completed",
               "run_id": "${{ github.run_id }}",


### PR DESCRIPTION
## Summary

The provisioning app's workflow webhook endpoint now requires an API key (launchdarkly/ld-core-demo-provisioning-app#35, deployed to prod 2026-07-09). This adds the `x-api-key` header to both webhook notification curls in `cloud_demo_environment_deprovisioning.yaml`, reading from the `WEBHOOK_API_KEY` repo secret.

The other workflows (`create`/`recreate`/`recreate_all`) don't call the webhook, so they need no changes.

## Impact if not merged

Nothing breaks hard — the curls have `|| echo` fallbacks — but webhook notifications get 403 and the provisioning dashboard stops receiving live status updates from deprovisioning runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)