### PR TITLE
Protect provisioning app namespaces from recreate-all

### DIFF
--- a/.github/workflows/cloud_demo_environment_recreate_all.yaml
+++ b/.github/workflows/cloud_demo_environment_recreate_all.yaml
@@ -46,8 +46,12 @@ jobs:
           EXCLUDED=$(echo "${{ github.event.inputs.exclude }}" | jq -R -c 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')
           echo "Excluded usernames: $EXCLUDED"
 
-          # Safety net: never touch system namespaces even if they somehow match
-          SYSTEM='["default","kube-system","kube-public","kube-node-lease","ingress-nginx"]'
+          # Safety net: never touch system namespaces even if they somehow match.
+          # mydemo/mydemo-staging host the provisioning app itself — its
+          # deployment is also named ld-core-demo-deployment, so discovery
+          # matches it and a recreate would destroy the provisioning app
+          # (this happened on 2026-07-09).
+          SYSTEM='["default","kube-system","kube-public","kube-node-lease","ingress-nginx","mydemo","mydemo-staging"]'
 
           ENVIRONMENTS=$(jq -R -s -c --argjson excluded "$EXCLUDED" --argjson system "$SYSTEM" '
             split("\n")


### PR DESCRIPTION
## Summary

`cloud_demo_environment_recreate_all.yaml` discovers environments by listing namespaces that contain a deployment named `ld-core-demo-deployment`. The **provisioning app's own production deployment** (namespace `mydemo`) has exactly that name, so it gets discovered as a "demo environment."

On 2026-07-09 a recreate-all run did exactly that: deleted the `mydemo` namespace (provisioning app, its secrets, its ALB ingress), deleted its Route 53 record, and installed a demo environment in its place — taking down `mydemo.launchdarklydemos.com` until it was manually recovered.

This adds `mydemo` and `mydemo-staging` to the existing protected-namespace safety net so it can't happen again.

(Longer-term structural fix worth considering: rename the provisioning app's deployment so it doesn't collide with the demo app's deployment name.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)